### PR TITLE
Techengme/myc 1834 p2 support farcaster links

### DIFF
--- a/app/api/link/get_detail/route.ts
+++ b/app/api/link/get_detail/route.ts
@@ -1,0 +1,28 @@
+import { NextRequest } from 'next/server'
+
+export async function GET(req: NextRequest) {
+  const url = req.nextUrl.searchParams.get('url')
+  try {
+    if (!url) throw Error('url is invalid.')
+    const options = {
+      method: 'POST',
+      headers: {
+        Authorization: 'Bearer sk_gfb7567odeiow27ucuzndu8j4uzyp07j',
+        'Content-Type': 'application/json',
+      },
+      body: '{"link":"https://warpcast.com/xcelencia/0x261df3bd","source":"API","forceNewSnapshot":"true","forceNewSnapshotRecursive":"true"}',
+    }
+
+    const response = await fetch('https://api.peekalink.io/', options)
+    const data = await response.json()
+    return Response.json(data)
+  } catch (e: any) {
+    console.log(e)
+    const message = e?.message ?? 'failed to get link preview.'
+    return Response.json({ message }, { status: 500 })
+  }
+}
+
+export const dynamic = 'force-dynamic'
+export const fetchCache = 'force-no-store'
+export const revalidate = 0

--- a/app/api/link/get_detail/route.ts
+++ b/app/api/link/get_detail/route.ts
@@ -10,7 +10,7 @@ export async function GET(req: NextRequest) {
         Authorization: 'Bearer sk_gfb7567odeiow27ucuzndu8j4uzyp07j',
         'Content-Type': 'application/json',
       },
-      body: '{"link":"https://warpcast.com/xcelencia/0x261df3bd","source":"API","forceNewSnapshot":"true","forceNewSnapshotRecursive":"true"}',
+      body: `{"link":"${decodeURIComponent(url)}","source":"API","forceNewSnapshot":"true","forceNewSnapshotRecursive":"true"}`,
     }
 
     const response = await fetch('https://api.peekalink.io/', options)

--- a/components/ImaginationPage/Imagination.tsx
+++ b/components/ImaginationPage/Imagination.tsx
@@ -1,11 +1,14 @@
 import { InstagramEmbed } from 'react-social-media-embed'
+import WarpcastPost from './WarpcastPost'
 
 const Imagination = ({ event }) => {
   const isIntagramPost = event.metadata.url.includes('instagram.com')
+  const isWarpcastPost = event.metadata.url.includes('warpcast.com')
 
   return (
     <div className="border-[2px] rounded-md p-2 border-black w-[350px] h-fit">
       {isIntagramPost && <InstagramEmbed url={event.metadata.url} width={328} />}
+      {isWarpcastPost && <WarpcastPost url={event.metadata.url} />}
       {event.metadata.message && <p className="pt-4">Message: {event.metadata.message}</p>}
     </div>
   )

--- a/components/ImaginationPage/WarpcastPost.tsx
+++ b/components/ImaginationPage/WarpcastPost.tsx
@@ -8,17 +8,18 @@ const WarpcastPost = ({ url }: WarpcastPostProps) => {
   const { isLoading, data } = useLinkPreview(url)
 
   return (
-    <div className="w-[328px] flex items-center justify-center">
+    <button
+      className="w-[328px] flex items-center justify-center"
+      type="button"
+      onClick={() => window.open(url, '_blank')}
+    >
       {isLoading ? (
         <LoaderCircle className="animate-spin" />
       ) : (
         // eslint-disable-next-line
-        <img
-          alt="warpcast"
-          src={data.image.original.url}
-        />
+        <img alt="warpcast" src={data.image.original.url} />
       )}
-    </div>
+    </button>
   )
 }
 

--- a/components/ImaginationPage/WarpcastPost.tsx
+++ b/components/ImaginationPage/WarpcastPost.tsx
@@ -1,0 +1,28 @@
+import useLinkPreview from '@/hooks/useLinkPreview'
+import { LoaderCircle } from 'lucide-react'
+import Image from 'next/image'
+
+interface WarpcastPostProps {
+  url: string
+}
+const WarpcastPost = ({ url }: WarpcastPostProps) => {
+  const { isLoading, data } = useLinkPreview(url)
+
+  return (
+    <div className="w-[328px] aspect-[128/72] relative flex justify-center items-center">
+      {isLoading ? (
+        <LoaderCircle className="animate-spin" />
+      ) : (
+        <Image
+          alt="warpcast"
+          src={data.image.large.url}
+          layout="fill"
+          objectFit="cover"
+          objectPosition="center"
+        />
+      )}
+    </div>
+  )
+}
+
+export default WarpcastPost

--- a/components/ImaginationPage/WarpcastPost.tsx
+++ b/components/ImaginationPage/WarpcastPost.tsx
@@ -1,6 +1,5 @@
 import useLinkPreview from '@/hooks/useLinkPreview'
 import { LoaderCircle } from 'lucide-react'
-import Image from 'next/image'
 
 interface WarpcastPostProps {
   url: string
@@ -9,16 +8,14 @@ const WarpcastPost = ({ url }: WarpcastPostProps) => {
   const { isLoading, data } = useLinkPreview(url)
 
   return (
-    <div className="w-[328px] aspect-[128/72] relative flex justify-center items-center">
+    <div className="w-[328px] flex items-center justify-center">
       {isLoading ? (
         <LoaderCircle className="animate-spin" />
       ) : (
-        <Image
+        // eslint-disable-next-line
+        <img
           alt="warpcast"
-          src={data.image.large.url}
-          layout="fill"
-          objectFit="cover"
-          objectPosition="center"
+          src={data.image.original.url}
         />
       )}
     </div>

--- a/hooks/useImagination.tsx
+++ b/hooks/useImagination.tsx
@@ -7,7 +7,11 @@ const useImagination = () => {
   useEffect(() => {
     const init = async () => {
       const points = await getMemoriesPoints()
-      const filtered = points.filter((point) => point.metadata.url.includes('instagram.com'))
+      const filtered = points.filter(
+        (point) =>
+          point.metadata.url.includes('instagram.com') ||
+          point.metadata.url.includes('warpcast.com'),
+      )
       setEvents(filtered)
     }
     init()

--- a/hooks/useLinkPreview.ts
+++ b/hooks/useLinkPreview.ts
@@ -1,0 +1,94 @@
+import { useQuery } from '@tanstack/react-query'
+
+export interface LinkPreview {
+  id: number
+  ok: boolean
+  url: string
+  domain: string
+  type: string
+  status: number
+  updatedAt: string
+  size: number
+  redirected: boolean
+  title: string
+  description: string
+  icon: {
+    url: string
+    width: number
+    height: number
+    backgroundColor: string
+  }
+  image: {
+    id: number
+    thumbnail: {
+      url: string
+      width: number
+      height: number
+    }
+    medium: {
+      url: string
+      width: number
+      height: number
+    }
+    large: {
+      url: string
+      width: number
+      height: number
+    }
+    original: {
+      url: string
+      width: number
+      height: number
+    }
+  }
+  page: {
+    size: number
+    estimatedReadingTimeInMinutes: 1
+    htmlUrl: string
+    markdownUrl: string
+    rawTextUrl: string
+    screenshot: {
+      thumbnail: {
+        url: string
+        width: number
+        height: number
+      }
+      medium: {
+        url: string
+        width: number
+        height: number
+      }
+      large: {
+        url: string
+        width: number
+        height: number
+      }
+      original: {
+        url: string
+        width: number
+        height: number
+      }
+    }
+  }
+  requestId: string
+}
+
+async function fetchLinkPreview(link: string): Promise<LinkPreview> {
+  const response = await fetch(`/api/link/get_detail?url=${encodeURIComponent(link)}`)
+  if (!response.ok) throw Error('failed to get link preview.')
+
+  const data = await response.json()
+  return data
+}
+
+const useLinkPreview = (link: string) => {
+  return useQuery({
+    queryKey: ['link_preview', link],
+    queryFn: () => fetchLinkPreview(link),
+    staleTime: 1000 * 60 * 5,
+    enabled: !!link,
+    refetchOnMount: true,
+  })
+}
+
+export default useLinkPreview

--- a/next.config.js
+++ b/next.config.js
@@ -39,6 +39,9 @@ const nextConfig = {
       {
         hostname: 'magic.decentralized-content.com',
       },
+      {
+        hostname: 'cdn.peekalink.io',
+      },
     ],
   },
 }

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "ethers": "^5",
     "framer-motion": "^11.3.9",
     "joi": "^17.13.3",
+    "link-preview-js": "^3.0.14",
     "lucide-react": "^0.475.0",
     "next": "^14.2.2",
     "react": "^18.3.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6222,6 +6222,20 @@ cheerio-select@^2.1.0:
     domhandler "^5.0.3"
     domutils "^3.0.1"
 
+cheerio@1.0.0-rc.11:
+  version "1.0.0-rc.11"
+  resolved "https://registry.yarnpkg.com/cheerio/-/cheerio-1.0.0-rc.11.tgz#1be84be1a126958366bcc57a11648cd9b30a60c2"
+  integrity sha512-bQwNaDIBKID5ts/DsdhxrjqFXYfLw4ste+wMKqWA8DyKcS4qwsPP4Bk8ZNaTJjvpiX/qW3BT4sU7d6Bh5i+dag==
+  dependencies:
+    cheerio-select "^2.1.0"
+    dom-serializer "^2.0.0"
+    domhandler "^5.0.3"
+    domutils "^3.0.1"
+    htmlparser2 "^8.0.1"
+    parse5 "^7.0.0"
+    parse5-htmlparser2-tree-adapter "^7.0.0"
+    tslib "^2.4.0"
+
 cheerio@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/cheerio/-/cheerio-1.0.0.tgz#1ede4895a82f26e8af71009f961a9b8cb60d6a81"
@@ -7078,7 +7092,7 @@ enhanced-resolve@^5.15.0:
     graceful-fs "^4.2.4"
     tapable "^2.2.0"
 
-entities@^4.2.0, entities@^4.5.0:
+entities@^4.2.0, entities@^4.4.0, entities@^4.5.0:
   version "4.5.0"
   resolved "https://registry.yarnpkg.com/entities/-/entities-4.5.0.tgz#5d268ea5e7113ec74c4d033b79ea5a35a488fb48"
   integrity sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==
@@ -8420,6 +8434,16 @@ html-parse-stringify@^3.0.1:
   dependencies:
     void-elements "3.1.0"
 
+htmlparser2@^8.0.1:
+  version "8.0.2"
+  resolved "https://registry.yarnpkg.com/htmlparser2/-/htmlparser2-8.0.2.tgz#f002151705b383e62433b5cf466f5b716edaec21"
+  integrity sha512-GYdjWKDkbRLkZ5geuHs5NY1puJ+PXwP7+fHPRz06Eirsb9ugf6d8kkXav6ADhcODhFFPMIXyxkxSuMf3D6NCFA==
+  dependencies:
+    domelementtype "^2.3.0"
+    domhandler "^5.0.3"
+    domutils "^3.0.1"
+    entities "^4.4.0"
+
 htmlparser2@^9.1.0:
   version "9.1.0"
   resolved "https://registry.yarnpkg.com/htmlparser2/-/htmlparser2-9.1.0.tgz#cdb498d8a75a51f739b61d3f718136c369bc8c23"
@@ -9260,6 +9284,14 @@ lines-and-columns@^1.1.6:
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/lines-and-columns/-/lines-and-columns-1.2.4.tgz#eca284f75d2965079309dc0ad9255abb2ebc1632"
   integrity sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==
+
+link-preview-js@^3.0.14:
+  version "3.0.14"
+  resolved "https://registry.yarnpkg.com/link-preview-js/-/link-preview-js-3.0.14.tgz#df4bb34d20432b00cddf2fc283a1d0ef12551875"
+  integrity sha512-BAGZGCogqsWfF3msPt0c6DXr4+4zv7fregAxPioFYZJKoQEbKhJOhmu7VQjZmtKd1VRQ6CbL80Ok2KhpIuWJnQ==
+  dependencies:
+    cheerio "1.0.0-rc.11"
+    url "0.11.0"
 
 lit-element@^3.3.0:
   version "3.3.3"
@@ -10360,6 +10392,11 @@ pump@^3.0.0:
     end-of-stream "^1.1.0"
     once "^1.3.1"
 
+punycode@1.3.2:
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/punycode/-/punycode-1.3.2.tgz#9653a036fb7c1ee42342f2325cceefea3926c48d"
+  integrity sha512-RofWgt/7fL5wP1Y7fxE7/EmTLzQVnB0ycyibJ0OOHIlJqTNzglYFxVwETOcIoJqJmpDXJ9xImDv+Fq34F/d4Dw==
+
 punycode@^1.2.4, punycode@^1.4.1:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-1.4.1.tgz#c0d5a63b2718800ad8e1eb0fa5269c84dd41845e"
@@ -10429,6 +10466,11 @@ querystring-es3@^0.2.0:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/querystring-es3/-/querystring-es3-0.2.1.tgz#9ec61f79049875707d69414596fd907a4d711e73"
   integrity sha512-773xhDQnZBMFobEiztv8LIl70ch5MSF/jUQVlhwFyBILqq96anmoctVIYz+ZRp0qbCKATTn6ev02M3r7Ga5vqA==
+
+querystring@0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/querystring/-/querystring-0.2.0.tgz#b209849203bb25df820da756e747005878521620"
+  integrity sha512-X/xY82scca2tau62i9mDyU9K+I+djTMUsvwf7xnUX5GLvVzgJybOJf4Y6o9Zx3oJK/LSXg5tTZBjwzqVPaPO2g==
 
 queue-microtask@^1.2.2:
   version "1.2.3"
@@ -12085,6 +12127,14 @@ url-set-query@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/url-set-query/-/url-set-query-1.0.0.tgz#016e8cfd7c20ee05cafe7795e892bd0702faa339"
   integrity sha512-3AChu4NiXquPfeckE5R5cGdiHCMWJx1dwCWOmWIL4KHAziJNOFIYJlpGFeKDvwLPHovZRCxK3cYlwzqI9Vp+Gg==
+
+url@0.11.0:
+  version "0.11.0"
+  resolved "https://registry.yarnpkg.com/url/-/url-0.11.0.tgz#3838e97cfc60521eb73c525a8e55bfdd9e2e28f1"
+  integrity sha512-kbailJa29QrtXnxgq+DdCEGlbTeYM2eJUxsz6vjZavrCYPMIFHMKQmSKYAIuUK2i7hgPm28a8piX5NTUtM/LKQ==
+  dependencies:
+    punycode "1.3.2"
+    querystring "0.2.0"
 
 url@^0.11.0:
   version "0.11.4"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for displaying embedded Warpcast posts alongside Instagram posts on the Imagination page.
  - Introduced preview images for Warpcast links, including loading indicators and enhanced image display.
  - Added a new API endpoint to fetch detailed link previews using an external service.
  - Introduced a hook to fetch and cache link preview data for enhanced content rendering.
- **Bug Fixes**
  - Improved URL filtering to include both Instagram and Warpcast links.
- **Chores**
  - Allowed images from "cdn.peekalink.io" for remote image loading.
  - Added the `link-preview-js` package as a new dependency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->