### PR TITLE
Ensure vertical stacking for DefaultPrompts

### DIFF
--- a/components/ChatPage/DefaultPrompts.tsx
+++ b/components/ChatPage/DefaultPrompts.tsx
@@ -24,7 +24,7 @@ const DefaultPrompts = ({ onPromptSelect }: DefaultPromptsProps) => {
         </p>
       </div>
       
-      <div className="grid grid-cols-1 md:grid-cols-2 gap-4 w-full max-w-2xl">
+      <div className="flex flex-col gap-4 w-full max-w-2xl">
         {prompts.map((prompt, index) => (
           <Card
             key={index}


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Make DefaultPrompts always stack vertically on all screen sizes.

---

[Slack Thread](https://voicefirsttech.slack.com/archives/C05QQQS3AH0/p1752264312663529?thread_ts=1752264312.663529&cid=C05QQQS3AH0)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the layout of prompt cards to display in a single vertical column instead of a two-column grid for a more consistent appearance across screen sizes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->