### PR TITLE
Update iframe in spin amp player

### DIFF
--- a/components/LandingPage/SpinampPlayer.tsx
+++ b/components/LandingPage/SpinampPlayer.tsx
@@ -5,7 +5,7 @@ const SpinampPlayer = () => {
       src="https://untitled.stream/embed/ebN3ugjZLgkc" 
       width="100%" 
       height="344" 
-      allowFullScreen="" 
+      allowFullScreen={true} 
       allow="picture-in-picture" 
       frameBorder="0" 
       loading="lazy"

--- a/components/LandingPage/SpinampPlayer.tsx
+++ b/components/LandingPage/SpinampPlayer.tsx
@@ -1,12 +1,14 @@
 const SpinampPlayer = () => {
   return (
-    <iframe
-      src="https://app.spinamp.xyz/embed/playlist/JOo8IpDlu2YXMiaHFhhi?colors=%7B%22primaryLight%22%3A%22%233d4ea3%22%2C%22primary%22%3A%22%232f3c7e%22%2C%22primaryDark%22%3A%22%23212a59%22%2C%22backgroundLight%22%3A%22%23111336%22%2C%22background%22%3A%22%230e0057%22%2C%22backgroundDark%22%3A%22%23000000%22%2C%22backdrop%22%3A%22rgba%280%2C0%2C0%2C0.65%29%22%2C%22borderColor%22%3A%22%232f3c7e%22%2C%22invertedBorderColor%22%3A%22%23f5f5f5%22%2C%22textColor%22%3A%22%23ffffff%22%2C%22invertedTextColor%22%3A%22%23f0eaeb%22%2C%22active%22%3A%22%23ffffff%22%2C%22activeBorder%22%3A%22%232f3c7e%22%2C%22activeText%22%3A%22%232f3c7e%22%2C%22favoritesColor%22%3A%22%237300ff%22%7D"
-      scrolling="no"
-      allow="autoplay; fullscreen; web-share"
-      sandbox="allow-popups allow-popups-to-escape-sandbox allow-same-origin allow-scripts allow-presentation"
-      width="250px"
-      height="350px"
+    <iframe 
+      style="border-radius: 24px" 
+      src="https://untitled.stream/embed/ebN3ugjZLgkc" 
+      width="100%" 
+      height="344" 
+      allowFullScreen="" 
+      allow="picture-in-picture" 
+      frameborder="0" 
+      loading="lazy"
     ></iframe>
   )
 }

--- a/components/LandingPage/SpinampPlayer.tsx
+++ b/components/LandingPage/SpinampPlayer.tsx
@@ -1,13 +1,13 @@
 const SpinampPlayer = () => {
   return (
     <iframe 
-      style="border-radius: 24px" 
+      style={{ borderRadius: "24px" }} 
       src="https://untitled.stream/embed/ebN3ugjZLgkc" 
       width="100%" 
       height="344" 
       allowFullScreen="" 
       allow="picture-in-picture" 
-      frameborder="0" 
+      frameBorder="0" 
       loading="lazy"
     ></iframe>
   )


### PR DESCRIPTION
Replace the Spinamp player iframe with a new untitled.stream embed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Updated the embedded player on the landing page with a new design and source, offering a refreshed look and improved playback options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->